### PR TITLE
fix: 🐛 skip validation when default_incomplete

### DIFF
--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -132,6 +132,10 @@ module StripeMock
           subscription[:status] = 'trialing'
         end
 
+        if params[:payment_behavior] == 'default_incomplete'
+          subscription[:status] = 'incomplete'
+        end
+
         if params[:cancel_at_period_end]
           subscription[:cancel_at_period_end] = true
           subscription[:canceled_at] = Time.now.utc.to_i
@@ -295,7 +299,7 @@ module StripeMock
         return if customer[:trial_end]
         return if params[:trial_end]
         return if subscription[:default_payment_method]
-        return if subscription[:payment_behavior] == 'default_incomplete'
+        return if params[:payment_behavior] == 'default_incomplete'
 
         plan_trial_period_days = plan[:trial_period_days] || 0
         plan_has_trial = plan_trial_period_days != 0 || plan[:amount] == 0 || plan[:trial_end]

--- a/lib/stripe_mock/request_handlers/subscriptions.rb
+++ b/lib/stripe_mock/request_handlers/subscriptions.rb
@@ -295,6 +295,7 @@ module StripeMock
         return if customer[:trial_end]
         return if params[:trial_end]
         return if subscription[:default_payment_method]
+        return if subscription[:payment_behavior] == 'default_incomplete'
 
         plan_trial_period_days = plan[:trial_period_days] || 0
         plan_has_trial = plan_trial_period_days != 0 || plan[:amount] == 0 || plan[:trial_end]

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'securerandom'
+require 'pry'
 
 shared_examples 'Customer Subscriptions with plans' do
   let(:gen_card_tk) { stripe_helper.generate_card_token }
@@ -290,14 +291,16 @@ shared_examples 'Customer Subscriptions with plans' do
       expect(customer.subscriptions.count).to eq(0)
     end
 
-    it "creates a subscription when default imcomplete subscribing a customer with no card" do
+    it "creates a subscription when subscription's payment_behavior is default_incomplete" do
       plan = stripe_helper.create_plan(id: 'enterprise', product: product.id, amount: 499)
       customer = Stripe::Customer.create(id: 'cardless')
 
       sub = Stripe::Subscription.create({ plan: plan.id, customer: customer.id, payment_behavior: 'default_incomplete' })
+      customer = Stripe::Customer.retrieve('cardless')
 
       expect(customer.subscriptions.count).to eq(1)
       expect(customer.subscriptions.data.first.id).to eq(sub.id)
+      expect(customer.subscriptions.data.first.status).to eq('incomplete')
     end
 
     it "throws an error when subscribing a customer with no card" do

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -290,6 +290,16 @@ shared_examples 'Customer Subscriptions with plans' do
       expect(customer.subscriptions.count).to eq(0)
     end
 
+    it "creates a subscription when default imcomplete subscribing a customer with no card" do
+      plan = stripe_helper.create_plan(id: 'enterprise', product: product.id, amount: 499)
+      customer = Stripe::Customer.create(id: 'cardless')
+
+      sub = Stripe::Subscription.create({ plan: plan.id, customer: customer.id, payment_behavior: 'default_incomplete' })
+
+      expect(customer.subscriptions.count).to eq(1)
+      expect(customer.subscriptions.data.first.id).to eq(sub.id)
+    end
+
     it "throws an error when subscribing a customer with no card" do
       plan = stripe_helper.create_plan(id: 'enterprise', product: product.id, amount: 499)
       customer = Stripe::Customer.create(id: 'cardless')


### PR DESCRIPTION
see: https://stripe.com/docs/billing/subscriptions/build-subscription?ui=elements